### PR TITLE
Ch4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,24 +1,5 @@
 inherit_from: .rubocop_todo.yml
 
-require:
-  - rubocop-rails
-  - rubocop-rspec
-  - rubocop-performance
-
-AllCops:
-  TargetRubyVersion: 2.7
-  TargetRailsVersion: 5.1.7
-  Exclude:
-    - "vendor/**/*"
-    - "bin/**/*"
-    - "db/**/*"
-    - "tmp/**/*"
-    - "node_modules/**/*"
-
-Rails:
-  Enabled: true
-inherit_from: .rubocop_todo.yml
-
 AllCops:
   Exclude:
     - db/migrate/*
@@ -46,7 +27,7 @@ Metrics/AbcSize:
   Max: 30
 
 MethodLength:
-  CountComments: false  # count full line comments?
+  CountComments: false # count full line comments?
   Max: 20
 
 ParenthesesAroundCondition:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,40 @@ AllCops:
 
 Rails:
   Enabled: true
+inherit_from: .rubocop_todo.yml
+
+AllCops:
+  Exclude:
+    - db/migrate/*
+    - db/schema.rb
+    - config/*
+    - config/**/*
+    - vendor/**/*
+    - tmp/**/*
+    - bin/*
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+    - lib/tasks/auto_annotate_models.rake
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be a Fixnum or
+  # a Float.
+  Max: 30
+
+MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 20
+
+ParenthesesAroundCondition:
+  AllowSafeAssignment: false
+
+AssignmentInCondition:
+  AllowSafeAssignment: false

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,13 +1,9 @@
 class StaticPagesController < ApplicationController
-  def home
-  end
+  def home; end
 
-  def help
-  end
+  def help; end
 
-  def about
-  end
+  def about; end
 
-  def contact
-  end
+  def contact; end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+
+	def full_title(page_title = "")
+		base_title = "Ruby on Rails Tutorial Sample App"
+		if page_title.empty?
+			base_title
+		else
+			page_title + " | " + base_title
+		end
+	end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,3 @@
-<%= provide(:title, "Home")%>
 <h1>Sample App</h1>
 <p>
 	This is the home page for the

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -32,7 +32,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = Rails.root.join('spec/fixtures').to_s
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,66 +1,66 @@
 require 'rails_helper'
 
-RSpec.describe "StaticPages", type: :request do
+RSpec.describe 'StaticPages', type: :request do
   let(:base_title) { 'Ruby on Rails Tutorial Sample App' }
 
-  describe "GET /home" do
-    it "returns http success" do
+  describe 'GET /home' do
+    it 'returns http success' do
       get static_pages_home_path
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /help" do
-    it "returns http success" do
+  describe 'GET /help' do
+    it 'returns http success' do
       get static_pages_help_path
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /about" do
-    it "returns http success" do
+  describe 'GET /about' do
+    it 'returns http success' do
       get static_pages_about_path
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /contact" do
-    it "returns http success" do
+  describe 'GET /contact' do
+    it 'returns http success' do
       get static_pages_contact_path
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /root" do
-    it "return http success" do
+  describe 'GET /root' do
+    it 'return http success' do
       get root_url
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "title /home" do
-    it "Homeがタイトルに含まれること" do
+  describe 'title /home' do
+    it 'Homeがタイトルに含まれること' do
       get static_pages_home_path
       expect(response.body).to include "<title>Home | #{base_title}</title>"
     end
   end
 
-  describe "title /help" do
-    it "Helpがタイトルに含まれること" do
+  describe 'title /help' do
+    it 'Helpがタイトルに含まれること' do
       get static_pages_help_path
       expect(response.body).to include "<title>Help | #{base_title}</title>"
     end
   end
 
-  describe "title /About" do
-    it "Aboutがタイトルに含まれること" do
+  describe 'title /About' do
+    it 'Aboutがタイトルに含まれること' do
       get static_pages_about_path
       expect(response.body).to include "<title>About | #{base_title}</title>"
     end
   end
 
-  describe "title /Contact" do
-    it "Contactがタイトルに含まれること" do
+  describe 'title /Contact' do
+    it 'Contactがタイトルに含まれること' do
       get static_pages_contact_path
       expect(response.body).to include "<title>Contact | #{base_title}</title>"
     end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe 'StaticPages', type: :request do
   end
 
   describe 'title /home' do
-    it 'Homeがタイトルに含まれること' do
+    it 'titleがRuby on Rails Tutorial Sample Appであること' do
       get static_pages_home_path
-      expect(response.body).to include "<title>Home | #{base_title}</title>"
+      expect(response.body).to include "<title>#{base_title}</title>"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
# Ch4
この章では、Robocopの自動修正を試みた。常盤さんから教えてもらった設定ファイルを使いました。
また、以下にこの章で提示されていた演習問題を解きました。
### 演習１

```ruby
city = "大阪市"
prefecture = "大阪府"

puts "#{prefecture} + #{"\t"} + #{city}" 
```

### 演習２

```ruby
p "racecar".length

p "racecar".reverse

s = "racecar"
p s == s.reverse

puts "It's a palindrome!" if s == s.reverse
```

### 演習３

```ruby
def palindrome_tester(s)
  if s == s.reverse
    puts "It's a palindrome!"
  else
    puts "It's not a palindrome."
  end
end

palindrome_tester("racecar")
palindrome_tester("onomatopoeia")

palindrome_tester("racecar").nil?
```

### 演習４

```ruby
a = "A man, a plan, a canal, Panama".split(",")

s = a.join()
s = s.split(" ").join()
palindrome_tester(s)
palindrome_tester(s.downcase)

("a".."z").to_a[6]
("a".."z").to_a[-7]

# ("a".."B")はどうやら無理。どういうロジックなんだろう？
# ("a".."B")はnilではない。だがしかし、to_aメソッドを使うと、空の配列が返ってくる
```

### 演習５

```ruby
(0..16).each do |n|
	puts n**2
end

def yeller(word)
  word.join().upcase()
end

def random_subdomain
  random_array = []
  8.times { random_array << rand(26) }
  random_array.map{ |n| ('a'..'z').to_a[n] }.join()
end

#名前付き
#def random_subdomain
#  Array.new(8).map{rand(26)}.map{|n| ('a'..'z').to_a[n] }.join()
#end

def string_shuffle(s)
  s.split('').shuffle().join()
end
```

### 演習６

```ruby
num = {
  'one' => 'uno',
  'two' => 'dos',
  'three' => 'tres'
}

num.each do |(key, value)|
  puts "'#{key}'はスペイン語で'#{value}'"
end

person1 = {
  first: "tanaka",
  last: "taro"
}

person2 = {
  first: "yamamoto",
  last: "hanako"
}

person3 = {
  first: "yamauti",
  last: "syouri"
}

params = {}

params[:father] = person1
params[:mother] = person2
params[:child] = person3

user = {
  name: "You Keitou",
  email: "k.you@ingage.jp",
  password: "abcdefghijk"
}

#この問題に関しては、mergeメソッドにブロックが渡されない場合は、キーが重複した時、othersの
#値が採用される。　つまり、この場合は "b" => 300が採用される。
puts ({ "a" => 100, "b" => 200 }.merge({ "b" => 300 }))
```

### 演習７

```ruby
#rangeクラスを生成するリテラルコンストラクタは
1..10
1...11

Range.new(1, 10)

puts (Range.new(1, 10) == (1..10))
=> true
# 同一性　同値性に関しては注意が必要

```

### 演習８

```ruby
class_name = (1..10).class
until class_name.nil?
  p class_name
  class_name = class_name.superclass
end

=> 
Range
Object
BasicObject

#以下のコードはうまく動いた。つまり、Stringは内部でselfを省略しても良い

class Word < String
  def palindrome?
    self == reverse
  end
end
s = Word.new("level")
p s.palindrome?

####
words = [Word.new("racecar"), Word.new("onomatopoeia"), Word.new("Malayalam".downcase)]
words.each do |n|
  p "#{n} is #{n.palindrome?}"
end

=>
"racecar is true"
"onomatopoeia is false"
"malayalam is true"

###shuffle を実装
class String
  def shuffle
    self.split('').shuffle.join
  end
end

p "foobar".shuffle
```