### PR TITLE
Sign upページを作成

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -81,10 +81,6 @@ p {
   }
 }
 
-img {
-  display: none;
-}
-
 /* footer */
 
 footer {
@@ -117,4 +113,41 @@ footer {
   width: 100%;
   margin-top: 45px;
   @include box_sizing;
+}
+
+/* sidebar */
+
+aside {
+  section.user_info {
+    margin-top: 20px;
+  }
+  section {
+    padding: 10px 0;
+    margin-top: 20px;
+    &:first-child {
+      border: 0;
+      padding-top: 0;
+    }
+    span {
+      display: block;
+      margin-bottom: 3px;
+      line-height: 1;
+    }
+    h1 {
+      font-size: 1.4em;
+      text-align: left;
+      letter-spacing: -1px;
+      margin-bottom: 3px;
+      margin-top: 0px;
+    }
+  }
+}
+
+.gravatar {
+  float: left;
+  margin-right: 10px;
+}
+
+.gravatar_edit {
+  margin-top: 15px;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -6,6 +6,12 @@ $gray-light: #777;
 $gray-dark: #555;
 $black-light: #222;
 
+@mixin box_sizing {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
 /* universal */
 body {
   padding-top: 60px;
@@ -103,4 +109,12 @@ footer {
       margin-left: 15px;
     }
   }
+}
+
+.debug_dump {
+  clear: both;
+  float: left;
+  width: 100%;
+  margin-top: 45px;
+  @include box_sizing;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -151,3 +151,19 @@ aside {
 .gravatar_edit {
   margin-top: 15px;
 }
+
+/* forms */
+
+input,
+textarea,
+select,
+.uneditable-input {
+  border: 1px solid #bbb;
+  width: 100%;
+  margin-bottom: 15px;
+  @include box_sizing;
+}
+
+input {
+  height: auto !important;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
 
   private
 
-    def user_params
-      params.require(:user).permit(:name, :email, :password, :password_confirmation)
-    end
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,24 @@
 class UsersController < ApplicationController
   def new
+    @user = User.new
   end
+
   def show
     @user = User.find(params[:id])
   end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,6 @@
 class UsersController < ApplicationController
   def new; end
+  def show
+    @user = User.find(params[:id])
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
-  def new; end
+  def new
+  end
   def show
     @user = User.find(params[:id])
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      flash[:success] = 'Welcome to the Sample App!'
       redirect_to @user
     else
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-
+      redirect_to @user
     else
       render 'new'
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,9 @@
 module UsersHelper
+
+  # 引数で与えられたユーザーのGravatar画像を返す
+  def gravatar_for(user)
+    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+    image_tag(gravatar_url, alt: user.name, class: "gravatar")
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,10 +1,8 @@
 module UsersHelper
-
   # 引数で与えられたユーザーのGravatar画像を返す
   def gravatar_for(user, size: 80)
-    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-	gravatar_size =
+    gravatar_id = Digest::MD5.hexdigest(user.email.downcase)
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
-    image_tag(gravatar_url, alt: user.name, class: "gravatar")
+    image_tag(gravatar_url, alt: user.name, class: 'gravatar')
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,9 +1,10 @@
 module UsersHelper
 
   # 引数で与えられたユーザーのGravatar画像を返す
-  def gravatar_for(user)
+  def gravatar_for(user, size: 80)
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+	gravatar_size =
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: "gravatar")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <div class="container">
       <%= yield %>
       <%= render 'layouts/footer'%>
+      <%= debug(params) if Rails.env.development? %>
     </div>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,10 @@
   <body>
     <%= render 'layouts/header'%>
     <div class="container">
+      <% flash.each do |message_type, message| %>
+        <div class="alert alert-<%= message_type %>"><%= message %></div>
+      <% end %>
+
       <%= yield %>
       <%= render 'layouts/footer'%>
       <%= debug(params) if Rails.env.development? %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      The form contains <%= pluralize(@user.errors.count, "error") %>.
+    </div>
+    <ul>
+    <% @user.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_for(@user) do |f| %>
+    <%= form_for(@user, url: signup_path) do |f| %>
       <%= render 'shared/error_messages' %>
 
       <%= f.label :name %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,24 @@
 <% provide(:title, 'Sign up') %>
 <h1>Sign up</h1>
-<p>This will be a signup page for new users.</p>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= f.label :name %>
+      <%= f.text_field :name, class: 'form-control' %>
+
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Create my account", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
   <aside class="col-md-4">
     <section class="user_info">
       <h1>
-        <%= gravatar_for @user %>
+        <%= gravatar_for @user ,size: 150 %>
         <%= @user.name %>
       </h1>
     </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,11 @@
-<%= @user.name %>, <%= @user.email %>, <%= @user.created_at%>, <%= @user.updated_ut%>
+<% provide(:title, @user.name) %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="user_info">
+      <h1>
+        <%= gravatar_for @user %>
+        <%= @user.name %>
+      </h1>
+    </section>
+  </aside>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,1 @@
+<%= @user.name %>, <%= @user.email %>, <%= @user.created_at%>, <%= @user.updated_ut%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get '/signup', to: 'users#new'
 
   root 'static_pages#home'
 
@@ -11,5 +10,7 @@ Rails.application.routes.draw do
 
   get '/about', to: 'static_pages#about'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/signup', to: 'users#new'
+  post '/signup', to: 'users#create'
   resources :users
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
 
   get '/about', to: 'static_pages#about'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :users
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,7 +16,7 @@
 FactoryBot.define do
   factory :testuser, class: User do
     name { Faker::Name.last_name }
-    email { Faker::Internet.free_email }
+    email { Faker::Internet.email }
     password { Faker::Internet.password }
     password_confirmation { password }
 
@@ -56,7 +56,7 @@ end
 
 def invalid_email_maker
   invalid_character = "! @ # $ % ^ & * ( ) = { } ¥ \' \" ' '"
-  email = Faker::Internet.free_email
+  email = Faker::Internet.email
   # ローカル部分とドメインに無効文字を挿入するかどうか
   insert_invalid_character_flag = [[true, true], [true, false], [false, true]]
   email.split('@')

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
 end
 
 def invalid_email_maker
-  invalid_character = %w[! @ # $ % ^ & * ( ) = { } ¥ ' " \ ]
+  invalid_character = ['!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '=', '{', '}', '¥', "'", '"', ' ']
   email = Faker::Internet.email
   # ローカル部分とドメインに無効文字を挿入するかどうか
   insert_invalid_character_flag = [[true, true], [true, false], [false, true]].sample

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'factory_bot'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
@@ -62,4 +62,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  #support helper
+  config.include FillUserFormHelper
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,7 +29,6 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-
 RSpec.configure do |config|
   include ApplicationHelper
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'factory_bot'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
@@ -31,13 +31,13 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 Capybara.register_driver :remote_chrome do |app|
-  url = "http://chrome:4444/wd/hub"
+  url = 'http://chrome:4444/wd/hub'
   caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
-    "goog:chromeOptions" => {
-      "args" => [
-        "no-sandbox",
-        "disable-gpu",
-        "window-size=1680,1050"
+    'goog:chromeOptions' => {
+      'args' => [
+        'no-sandbox',
+        'disable-gpu',
+        'window-size=1680,1050'
       ]
     }
   )
@@ -84,6 +84,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
-  #support helper
+  # support helper
   config.include FillUserFormHelper
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,8 +29,30 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Capybara.register_driver :remote_chrome do |app|
+  url = "http://chrome:4444/wd/hub"
+  caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
+    "goog:chromeOptions" => {
+      "args" => [
+        "no-sandbox",
+        "disable-gpu",
+        "window-size=1680,1050"
+      ]
+    }
+  )
+  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
+end
+
 RSpec.configure do |config|
   include ApplicationHelper
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :remote_chrome
+    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+    Capybara.server_port = 3000
+    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+  end
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures').to_s
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,6 @@ require 'factory_bot'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
@@ -30,29 +29,10 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-Capybara.register_driver :remote_chrome do |app|
-  url = 'http://chrome:4444/wd/hub'
-  caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
-    'goog:chromeOptions' => {
-      'args' => [
-        'no-sandbox',
-        'disable-gpu',
-        'window-size=1680,1050'
-      ]
-    }
-  )
-  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
-end
 
 RSpec.configure do |config|
   include ApplicationHelper
 
-  config.before(:each, type: :system, js: true) do
-    driven_by :remote_chrome
-    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
-    Capybara.server_port = 3000
-    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
-  end
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures').to_s
 
@@ -85,5 +65,4 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   # support helper
-  config.include FillUserFormHelper
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,16 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Users', type: :request do
   let(:base_title) { 'Ruby on Rails Tutorial Sample App' }
 
-  before do
-    @invalid_user_factory_params = [
-      [:email_invalid_character],
-      [:email_length_variable, { email_length: 256 }],
-      [:username_length_variable, { name_length: 51 }],
-      [:non_password_user],
-      [:password_length_variable, { password_length: 5 }]
-    ]
-  end
-
   describe 'GET /signup' do
     it 'returns http success' do
       get signup_path
@@ -21,9 +11,14 @@ RSpec.describe 'Users', type: :request do
   end
 
   describe 'post /signup' do
+    let(:user_attributes) { {
+        name: 'keito',
+        email: 'k.you@ingage.jp',
+        password: '123456',
+        password_confirmation: '123456'
+    } }
     context '有効なユーザー' do
-      let(:user_attributes) { attributes_for(:testuser) }
-      it 'DBに登録される' do
+      it 'DBに登録されること' do
         expect do
           post signup_path, params: {
             user: user_attributes
@@ -32,14 +27,45 @@ RSpec.describe 'Users', type: :request do
       end
     end
 
-    context '無効なユーザー' do
-      let(:user_attributes) { attributes_for(:testuser, *@invalid_user_factory_params.sample) }
-      it 'DBに登録されない' do
+    context '名前が無効なユーザー' do
+      let(:invalid_user_attributes) { {
+        name: 'a' * 51,
+        user_attributes.except(:name)
+      }}
+      it 'DBに登録されないこと' do
         expect do
           post signup_path, params: {
             user: user_attributes
           }
         end.to change { User.count }.by(0)
+      end
+    end
+
+    context 'メールアドレスが無効なユーザー' do
+      let(:invalid_user_attributes) { {
+        email: 'a' * 244 + '@example.com',
+        user_attributes.except(:email)
+      }}
+      it 'DBに登録されないこと' do
+        expect do
+          post signup_path, params: {
+            user: user_attributes
+          }
+        end .to change { User.count }.by(0)
+      end
+    end
+
+    context 'パスワードが無効なユーザー' do
+      let(:invalid_user_attributes) { {
+        password: 'a' * 5,
+        user_attributes.except(:password)
+      }}
+      it 'DBに登録されないこと' do
+        expect do
+          post signup_path, params: {
+            user: user_attributes
+          }
+        end .to change { User.count }.by(0)
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'Users', type: :request do
 
   before do
     @invalid_user_factory_params = [
-        [:email_invalid_character],
-        [:email_length_variable, email_length: 256],
-        [:username_length_variable, {name_length: 51}],
-        [:non_password_user],
-        [:password_length_variable, {password_length: 5}]
-      ]
+      [:email_invalid_character],
+      [:email_length_variable, { email_length: 256 }],
+      [:username_length_variable, { name_length: 51 }],
+      [:non_password_user],
+      [:password_length_variable, { password_length: 5 }]
+    ]
   end
 
   describe 'GET /signup' do
@@ -22,24 +22,24 @@ RSpec.describe 'Users', type: :request do
 
   describe 'post /signup' do
     context '有効なユーザー' do
-      let(:user_attributes) {  attributes_for(:testuser)  }
+      let(:user_attributes) { attributes_for(:testuser) }
       it 'DBに登録される' do
-        expect {
+        expect do
           post signup_path, params: {
             user: user_attributes
           }
-        }.to change{User.count}.by(1)
+        end.to change { User.count }.by(1)
       end
     end
 
     context '無効なユーザー' do
       let(:user_attributes) { attributes_for(:testuser, *@invalid_user_factory_params.sample) }
       it 'DBに登録されない' do
-        expect {
+        expect do
           post signup_path, params: {
             user: user_attributes
           }
-        }.to change{User.count}.by(0)
+        end.to change { User.count }.by(0)
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,6 +3,16 @@ require 'rails_helper'
 RSpec.describe 'Users', type: :request do
   let(:base_title) { 'Ruby on Rails Tutorial Sample App' }
 
+  before do
+    @invalid_user_factory_params = [
+        [:email_invalid_character],
+        [:email_length_variable, email_length: 256],
+        [:username_length_variable, {name_length: 51}],
+        [:non_password_user],
+        [:password_length_variable, {password_length: 5}]
+      ]
+  end
+
   describe 'GET /signup' do
     it 'returns http success' do
       get signup_path
@@ -11,14 +21,25 @@ RSpec.describe 'Users', type: :request do
   end
 
   describe 'post /signup' do
+    context '有効なユーザー' do
+      let(:user_attributes) {  attributes_for(:testuser)  }
+      it 'DBに登録される' do
+        expect {
+          post signup_path, params: {
+            user: user_attributes
+          }
+        }.to change{User.count}.by(1)
+      end
+    end
+
     context '無効なユーザー' do
-      let(:user_params) {  build(:testuser).attributes  }
+      let(:user_attributes) { attributes_for(:testuser, *@invalid_user_factory_params.sample) }
       it 'DBに登録されない' do
         expect {
           post signup_path, params: {
-            user: user_params
+            user: user_attributes
           }
-        }.to change{User.count}.by(1)
+        }.to change{User.count}.by(0)
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -10,6 +10,19 @@ RSpec.describe 'Users', type: :request do
     end
   end
 
+  describe 'post /signup' do
+    context '無効なユーザー' do
+      let(:user_params) {  build(:testuser).attributes  }
+      it 'DBに登録されない' do
+        expect {
+          post signup_path, params: {
+            user: user_params
+          }
+        }.to change{User.count}.by(1)
+      end
+    end
+  end
+
   describe 'title /signup' do
     it "title が #{full_title('Sign up')}となっていること" do
       get signup_path

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -11,61 +11,69 @@ RSpec.describe 'Users', type: :request do
   end
 
   describe 'post /signup' do
-    let(:user_attributes) { {
+    let(:base_user_attributes) do
+      {
         name: 'keito',
         email: 'k.you@ingage.jp',
         password: '123456',
         password_confirmation: '123456'
-    } }
+      }
+    end
     context '有効なユーザー' do
       it 'DBに登録されること' do
         expect do
           post signup_path, params: {
-            user: user_attributes
+            user: base_user_attributes
           }
         end.to change { User.count }.by(1)
       end
     end
 
     context '名前が無効なユーザー' do
-      let(:invalid_user_attributes) { {
-        name: 'a' * 51,
-        user_attributes.except(:name)
-      }}
+      let(:invalid_user_attributes) do
+        {
+          name: 'a' * 51,
+          **base_user_attributes.except(:name)
+        }
+      end
       it 'DBに登録されないこと' do
         expect do
           post signup_path, params: {
-            user: user_attributes
+            user: invalid_user_attributes
           }
         end.to change { User.count }.by(0)
       end
     end
 
     context 'メールアドレスが無効なユーザー' do
-      let(:invalid_user_attributes) { {
-        email: 'a' * 244 + '@example.com',
-        user_attributes.except(:email)
-      }}
+      let(:invalid_user_attributes) do
+        {
+          email: '$$you@example.com',
+          **base_user_attributes.except(:email)
+        }
+      end
       it 'DBに登録されないこと' do
         expect do
           post signup_path, params: {
-            user: user_attributes
+            user: invalid_user_attributes
           }
-        end .to change { User.count }.by(0)
+        end.to change { User.count }.by(0)
       end
     end
 
     context 'パスワードが無効なユーザー' do
-      let(:invalid_user_attributes) { {
-        password: 'a' * 5,
-        user_attributes.except(:password)
-      }}
+      let(:invalid_user_attributes) do
+        {
+          password: 'a' * 5,
+          **base_user_attributes.except(:password)
+        }
+      end
       it 'DBに登録されないこと' do
         expect do
           post signup_path, params: {
-            user: user_attributes
+            user: invalid_user_attributes
           }
-        end .to change { User.count }.by(0)
+        end.to change { User.count }.by(0)
       end
     end
   end

--- a/spec/support/fill_user_form_helper.rb
+++ b/spec/support/fill_user_form_helper.rb
@@ -1,0 +1,8 @@
+module FillUserFormHelper
+	def fill_in_form(user_data)
+		fill_in 'user[name]', with: user_data.name
+		fill_in 'user[email]', with: user_data.email
+		fill_in 'user[password]', with: user_data.password
+		fill_in 'user[password]', with: user_data.password_confirmation
+	end
+end

--- a/spec/support/fill_user_form_helper.rb
+++ b/spec/support/fill_user_form_helper.rb
@@ -1,8 +1,8 @@
 module FillUserFormHelper
 	def fill_in_form(user_data)
-		fill_in 'user[name]', with: user_data.name
-		fill_in 'user[email]', with: user_data.email
-		fill_in 'user[password]', with: user_data.password
-		fill_in 'user[password]', with: user_data.password_confirmation
+		fill_in 'user[name]', with: user_data[:name]
+		fill_in 'user[email]', with: user_data[:email]
+		fill_in 'user[password]', with: user_data[:password]
+		fill_in 'user[password_confirmation]', with: user_data[:password_confirmation]
 	end
 end

--- a/spec/support/fill_user_form_helper.rb
+++ b/spec/support/fill_user_form_helper.rb
@@ -1,8 +1,0 @@
-module FillUserFormHelper
-  def fill_in_form(user_data)
-    fill_in 'user[name]', with: user_data[:name]
-    fill_in 'user[email]', with: user_data[:email]
-    fill_in 'user[password]', with: user_data[:password]
-    fill_in 'user[password_confirmation]', with: user_data[:password_confirmation]
-  end
-end

--- a/spec/support/fill_user_form_helper.rb
+++ b/spec/support/fill_user_form_helper.rb
@@ -1,8 +1,8 @@
 module FillUserFormHelper
-	def fill_in_form(user_data)
-		fill_in 'user[name]', with: user_data[:name]
-		fill_in 'user[email]', with: user_data[:email]
-		fill_in 'user[password]', with: user_data[:password]
-		fill_in 'user[password_confirmation]', with: user_data[:password_confirmation]
-	end
+  def fill_in_form(user_data)
+    fill_in 'user[name]', with: user_data[:name]
+    fill_in 'user[email]', with: user_data[:email]
+    fill_in 'user[password]', with: user_data[:password]
+    fill_in 'user[password_confirmation]', with: user_data[:password_confirmation]
+  end
 end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe 'StaticPages', type: :system do
   before do
     driven_by(:rack_test)
+    @invalid_user_factory_params = [
+      [:email_invalid_character],
+      [:email_length_variable, email_length: 256],
+      [:username_length_variable, {name_length: 51}],
+      [:non_password_user],
+      [:password_length_variable, {password_length: 5}]
+    ]
   end
 
   describe 'root' do
@@ -18,4 +25,39 @@ RSpec.describe 'StaticPages', type: :system do
       expect(page).to have_link 'About', href: about_path
     end
   end
+
+  describe 'signup page' do
+    context '無効なユーザーが送信されたとき' do
+      let(:user) { build( :testuser, *@invalid_user_factory_params.sample ) }
+      it 'エラーが表示される' do
+        visit signup_path
+        fill_in_form(user)
+        find('input[name="commit"]').click
+        expect(page).to have_content /The form contains [0-9]+ errors./
+      end
+
+      it 'ユーザーは登録されない' do
+        visit signup_path
+        fill_in_form(user)
+        expect{
+          find('input[name="commit"]').click
+        }.to change { User.count }.by(0)
+      end
+    end
+
+    context '有効なユーザーが送信されたとき' do
+      let(:user) { build(:testuser) }
+      it 'ユーザーが登録される' do
+        visit signup_path
+        fill_in_form(user)
+        p user
+        expect{
+          find('input[name="commit"]').click
+        }.to change { User.count }.by(1)
+      end
+    end
+
+  end
+
 end
+

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,16 +1,24 @@
 require 'rails_helper'
 
+# RSpect helper
+def fill_in_form(user_data)
+  fill_in 'user[name]', with: user_data[:name]
+  fill_in 'user[email]', with: user_data[:email]
+  fill_in 'user[password]', with: user_data[:password]
+  fill_in 'user[password_confirmation]', with: user_data[:password_confirmation]
+end
+
 RSpec.describe 'StaticPages', type: :system, js: true do
   before do
     driven_by(:rack_test)
-    @invalid_user_factory_params = [
-      [:email_invalid_character],
-      [:email_length_variable, { email_length: 256 }],
-      [:username_length_variable, { name_length: 51 }],
-      [:non_password_user],
-      [:password_length_variable, { password_length: 5 }]
-    ]
   end
+  let(:base_user_attributes) {
+  {
+    name: 'keito',
+    email: 'k.you@example.jp',
+    password: '123456',
+    password_confirmation: '123456'
+  }}
 
   describe 'root' do
     it 'root_pathへのリンクが二つ、help、about、contactへのリンクが表示されていること' do
@@ -27,43 +35,70 @@ RSpec.describe 'StaticPages', type: :system, js: true do
   end
 
   describe 'signup page' do
-    context '無効なユーザーが送信されたとき' do
-      let(:user_attributes) { attributes_for(:testuser, *@invalid_user_factory_params.sample) }
+    shared_context '無効なユーザーを入力する' do |invalid_attr, invalid_attr_value|
+      if invalid_attr != :password
+        let(:invalid_user_attributes) {{
+          invalid_attr => invalid_attr_value,
+          **base_user_attributes.except(invalid_attr)
+        }}
+      else
+        let(:invalid_user_attributes) {{
+          password: invalid_attr_value,
+          password_confirmation: invalid_attr_value,
+          **base_user_attributes.except(:password, :password_confirmation)
+        }}
+      end
+    end
+
+    shared_examples 'エラーが発生する' do
       it 'エラーが表示される' do
         visit signup_path
-        fill_in_form(user_attributes)
+        fill_in_form(invalid_user_attributes)
         find('input[name="commit"]').click
-        expect(page).to have_content(/The form contains [0-9]+ errors*./)
+        expect(page).to have_content('The form contains 1 error.')
       end
 
       it 'ユーザーは登録されない' do
         visit signup_path
-        fill_in_form(user_attributes)
+        fill_in_form(invalid_user_attributes)
         expect do
           find('input[name="commit"]').click
         end.to change { User.count }.by(0)
       end
     end
 
+    context '名前が無効なユーザーが送信されたとき' do
+      include_context '無効なユーザーを入力する', :name, 'a' * 51
+      it_behaves_like 'エラーが発生する'
+    end
+
+    context 'メールアドレスが無効なユーザーが送信されたとき' do
+      include_context '無効なユーザーを入力する', :email, 'a' * 244 + '@example.com'
+      it_behaves_like 'エラーが発生する'
+    end
+
+    context 'パスワードが無効なユーザーが送信されたとき' do
+      include_context '無効なユーザーを入力する', :password, 'a' * 5
+      it_behaves_like 'エラーが発生する'
+    end
+
     context '有効なユーザーが送信されたとき' do
-      let(:user_attributes) { attributes_for(:testuser) }
       it 'ユーザーが登録される' do
         visit signup_path
-        p user_attributes
-        fill_in_form(user_attributes)
+        fill_in_form(base_user_attributes)
         expect do
           click_button 'Create my account'
         end.to change(User, :count).by(1)
       end
       it 'リダイレクトされる' do
         visit signup_path
-        fill_in_form(user_attributes)
+        fill_in_form(base_user_attributes)
         find('input[name="commit"]').click
-        expect(current_path).to eq(user_path(User.find_by(email: user_attributes[:email])))
+        expect(current_path).to eq(user_path(User.find_by(email: base_user_attributes[:email])))
       end
       it '成功のflashが出る' do
         visit signup_path
-        fill_in_form(user_attributes)
+        fill_in_form(base_user_attributes)
         find('input[name="commit"]').click
         expect(page).to have_selector 'div', class: 'alert-success'
       end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'StaticPages', type: :system do
+RSpec.describe 'StaticPages', type: :system, js: true do
   before do
     driven_by(:rack_test)
     @invalid_user_factory_params = [
@@ -28,17 +28,17 @@ RSpec.describe 'StaticPages', type: :system do
 
   describe 'signup page' do
     context '無効なユーザーが送信されたとき' do
-      let(:user) { build( :testuser, *@invalid_user_factory_params.sample ) }
+      let(:user_attributes) { attributes_for( :testuser, *@invalid_user_factory_params.sample ) }
       it 'エラーが表示される' do
         visit signup_path
-        fill_in_form(user)
+        fill_in_form(user_attributes)
         find('input[name="commit"]').click
-        expect(page).to have_content /The form contains [0-9]+ errors./
+        expect(page).to have_content /The form contains [0-9]+ error[s]*./
       end
 
       it 'ユーザーは登録されない' do
         visit signup_path
-        fill_in_form(user)
+        fill_in_form(user_attributes)
         expect{
           find('input[name="commit"]').click
         }.to change { User.count }.by(0)
@@ -46,19 +46,20 @@ RSpec.describe 'StaticPages', type: :system do
     end
 
     context '有効なユーザーが送信されたとき' do
-      let(:user) { build(:testuser) }
+      let(:user_attributes) { attributes_for(:testuser) }
       it 'ユーザーが登録される' do
         visit signup_path
-        fill_in_form(user)
+        p user_attributes
+        fill_in_form(user_attributes)
         expect{
           click_button 'Create my account'
-        }.to change { User.count }.by(1)
+        }.to change(User, :count).by(1)
       end
       it 'リダイレクトされる' do
         visit signup_path
-        fill_in_form(user)
+        fill_in_form(user_attributes)
         find('input[name="commit"]').click
-        expect(current_path).to eq(user_path)
+        expect(current_path).to eq(user_path(User.find_by(email: user_attributes[:email])))
       end
     end
   end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe 'StaticPages', type: :system, js: true do
     driven_by(:rack_test)
     @invalid_user_factory_params = [
       [:email_invalid_character],
-      [:email_length_variable, email_length: 256],
-      [:username_length_variable, {name_length: 51}],
+      [:email_length_variable, { email_length: 256 }],
+      [:username_length_variable, { name_length: 51 }],
       [:non_password_user],
-      [:password_length_variable, {password_length: 5}]
+      [:password_length_variable, { password_length: 5 }]
     ]
   end
 
@@ -28,20 +28,20 @@ RSpec.describe 'StaticPages', type: :system, js: true do
 
   describe 'signup page' do
     context '無効なユーザーが送信されたとき' do
-      let(:user_attributes) { attributes_for( :testuser, *@invalid_user_factory_params.sample ) }
+      let(:user_attributes) { attributes_for(:testuser, *@invalid_user_factory_params.sample) }
       it 'エラーが表示される' do
         visit signup_path
         fill_in_form(user_attributes)
         find('input[name="commit"]').click
-        expect(page).to have_content /The form contains [0-9]+ error[s]*./
+        expect(page).to have_content(/The form contains [0-9]+ errors*./)
       end
 
       it 'ユーザーは登録されない' do
         visit signup_path
         fill_in_form(user_attributes)
-        expect{
+        expect do
           find('input[name="commit"]').click
-        }.to change { User.count }.by(0)
+        end.to change { User.count }.by(0)
       end
     end
 
@@ -51,9 +51,9 @@ RSpec.describe 'StaticPages', type: :system, js: true do
         visit signup_path
         p user_attributes
         fill_in_form(user_attributes)
-        expect{
+        expect do
           click_button 'Create my account'
-        }.to change(User, :count).by(1)
+        end.to change(User, :count).by(1)
       end
       it 'リダイレクトされる' do
         visit signup_path
@@ -65,10 +65,8 @@ RSpec.describe 'StaticPages', type: :system, js: true do
         visit signup_path
         fill_in_form(user_attributes)
         find('input[name="commit"]').click
-        expect(page).to have_selector 'div' , class: 'alert-success'
+        expect(page).to have_selector 'div', class: 'alert-success'
       end
     end
   end
-
 end
-

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'StaticPages', type: :system, js: true do
         visit signup_path
         fill_in_form(user_attributes)
         find('input[name="commit"]').click
-        expect(page).to have_selector ''
+        expect(page).to have_selector 'div' , class: 'alert-success'
       end
     end
   end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -12,13 +12,14 @@ RSpec.describe 'StaticPages', type: :system, js: true do
   before do
     driven_by(:rack_test)
   end
-  let(:base_user_attributes) {
-  {
-    name: 'keito',
-    email: 'k.you@example.jp',
-    password: '123456',
-    password_confirmation: '123456'
-  }}
+  let(:base_user_attributes) do
+    {
+      name: 'keito',
+      email: 'k.you@example.jp',
+      password: '123456',
+      password_confirmation: '123456'
+    }
+  end
 
   describe 'root' do
     it 'root_pathへのリンクが二つ、help、about、contactへのリンクが表示されていること' do
@@ -37,16 +38,20 @@ RSpec.describe 'StaticPages', type: :system, js: true do
   describe 'signup page' do
     shared_context '無効なユーザーを入力する' do |invalid_attr, invalid_attr_value|
       if invalid_attr != :password
-        let(:invalid_user_attributes) {{
-          invalid_attr => invalid_attr_value,
-          **base_user_attributes.except(invalid_attr)
-        }}
+        let(:invalid_user_attributes) do
+          {
+            invalid_attr => invalid_attr_value,
+            **base_user_attributes.except(invalid_attr)
+          }
+        end
       else
-        let(:invalid_user_attributes) {{
-          password: invalid_attr_value,
-          password_confirmation: invalid_attr_value,
-          **base_user_attributes.except(:password, :password_confirmation)
-        }}
+        let(:invalid_user_attributes) do
+          {
+            password: invalid_attr_value,
+            password_confirmation: invalid_attr_value,
+            **base_user_attributes.except(:password, :password_confirmation)
+          }
+        end
       end
     end
 
@@ -73,7 +78,7 @@ RSpec.describe 'StaticPages', type: :system, js: true do
     end
 
     context 'メールアドレスが無効なユーザーが送信されたとき' do
-      include_context '無効なユーザーを入力する', :email, 'a' * 244 + '@example.com'
+      include_context '無効なユーザーを入力する', :email, "#{'a' * 244}@example.com"
       it_behaves_like 'エラーが発生する'
     end
 

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -50,13 +50,17 @@ RSpec.describe 'StaticPages', type: :system do
       it 'ユーザーが登録される' do
         visit signup_path
         fill_in_form(user)
-        p user
         expect{
-          find('input[name="commit"]').click
+          click_button 'Create my account'
         }.to change { User.count }.by(1)
       end
+      it 'リダイレクトされる' do
+        visit signup_path
+        fill_in_form(user)
+        find('input[name="commit"]').click
+        expect(current_path).to eq(user_path)
+      end
     end
-
   end
 
 end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe 'StaticPages', type: :system, js: true do
         find('input[name="commit"]').click
         expect(current_path).to eq(user_path(User.find_by(email: user_attributes[:email])))
       end
+      it '成功のflashが出る' do
+        visit signup_path
+        fill_in_form(user_attributes)
+        find('input[name="commit"]').click
+        expect(page).to have_selector ''
+      end
     end
   end
 


### PR DESCRIPTION
前章で、Userモデルが完成したので、登録機能の追加を行いました。

演習問題に対する個人の考えを以下に述べます。

- オプション引数とキーワード引数
   - オプション引数はdef test(**arg) or def test(options {})のような定義をする。たくさん引数としてとれる。
   - キーワード引数は　指定されたキーワード以外が渡されたらだめ。
- 送信前と送信済みフォームのURLがなぜ違っているのか
   - resources :users で URL /users が indexアクションにデフォルト対応するようになっている。
   - get /signup to: User#new で　/signup は独自で設定したものである。
   - この二つの設定によってURLが変わってしまっている。

今回参考にした記事
https://qiita.com/morrr/items/0e24251c049180218db4#%E8%A6%81%E7%B4%A0%E3%81%AE%E5%86%85%E5%AE%B9%E3%82%92%E7%A2%BA%E8%AA%8D%E3%81%99%E3%82%8Bcapybaranodematcher

https://qiita.com/jnchito/items/607f956263c38a5fec24#%E7%8F%BE%E5%9C%A8%E3%81%AE%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%8C%E7%89%B9%E5%AE%9A%E3%81%AE%E3%83%91%E3%82%B9%E3%81%A7%E3%81%82%E3%82%8B%E3%81%93%E3%81%A8%E3%82%92%E6%A4%9C%E8%A8%BC%E3%81%99%E3%82%8B